### PR TITLE
Add jacoco with a plugin that automatically configures it for all submodules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - extra
 
 script:
-    - ./gradlew check test
+    - ./gradlew test
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.11"
+        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.13.0"
     }
 }
 
@@ -16,6 +17,9 @@ allprojects {
     }
 }
 
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+apply plugin: "com.vanniktech.android.junit.jacoco"


### PR DESCRIPTION
:pushpin: **References**

* Issue: #11 

:cyclone: **Git merge message**

* Add a gradle plugin to automatically run jacoco for all gradle submodules automatically. See https://github.com/vanniktech/gradle-android-junit-jacoco-plugin