### PR TITLE
Add a new detector verifying there are no classes with only constants

### DIFF
--- a/detectors/src/main/kotlin/com/serchinastico/lin/detectors/LinIssueRegistry.kt
+++ b/detectors/src/main/kotlin/com/serchinastico/lin/detectors/LinIssueRegistry.kt
@@ -11,6 +11,7 @@ class LinIssueRegistry : IssueRegistry() {
         NoPublicViewPropertiesDetector.issue,
         NoSetOnClickListenerCallsDetector.issue,
         NoMoreThanOneGsonInstanceDetector.issue,
-        NoMoreThanOneDateInstanceDetector.issue
+        NoMoreThanOneDateInstanceDetector.issue,
+        OnlyConstantsInTypeDetector.issue
     )
 }

--- a/detectors/src/main/kotlin/com/serchinastico/lin/detectors/noDataFrameworksFromAndroidClassDetector.kt
+++ b/detectors/src/main/kotlin/com/serchinastico/lin/detectors/noDataFrameworksFromAndroidClassDetector.kt
@@ -12,10 +12,10 @@ import com.serchinastico.lin.dsl.issue
 fun noDataFrameworksFromAndroidClass() = detector(
     issue(
         Scope.JAVA_FILE_SCOPE,
-        "Framework classes to get or store data should never be called from Activities, Fragments or any other" +
-                " Android related view.",
-        "Your Android classes should not be responsible for retrieving or storing information, that should be " +
-                "responsibility of another classes.",
+        """Framework classes to get or store data should never be called from Activities, Fragments or any other
+                | Android related view.""".trimMargin(),
+        """Your Android classes should not be responsible for retrieving or storing information, that should be
+                | responsibility of another classes.""".trimMargin(),
         Category.INTEROPERABILITY
     )
 ) {

--- a/detectors/src/main/kotlin/com/serchinastico/lin/detectors/noElseInSwitchWithEnumOrSealedDetector.kt
+++ b/detectors/src/main/kotlin/com/serchinastico/lin/detectors/noElseInSwitchWithEnumOrSealedDetector.kt
@@ -11,8 +11,8 @@ fun noElseInSwitchWithEnumOrSealed() = detector(
     issue(
         Scope.JAVA_FILE_SCOPE,
         "There should not be else/default branches on a switch statement checking for enum/sealed class values",
-        "Adding an else/default branch breaks extensibility because it won't let you know if there is a missing " +
-                "implementation when adding new types to the enum/sealed class",
+        """Adding an else/default branch breaks extensibility because it won't let you know if there is a missing
+                | implementation when adding new types to the enum/sealed class""".trimMargin(),
         Category.CORRECTNESS
     )
 ) {

--- a/detectors/src/main/kotlin/com/serchinastico/lin/detectors/noPublicViewPropertiesDetector.kt
+++ b/detectors/src/main/kotlin/com/serchinastico/lin/detectors/noPublicViewPropertiesDetector.kt
@@ -14,9 +14,10 @@ fun noPublicViewProperties() = detector(
     issue(
         Scope.JAVA_FILE_SCOPE,
         "View properties should always be private",
-        "Exposing views to other classes, be it from activities or custom views is leaking too much" +
-                " information to other classes and is prompt to break if the inner implementation of" +
-                " the layout changes, the only exception is if those views are part of an implemented interface",
+        """Exposing views to other classes, be it from activities or custom views is leaking too much
+                | information to other classes and is prompt to break if the inner implementation of
+                | the layout changes, the only exception is if those views are part of an implemented
+                | interface""".trimMargin(),
         Category.CORRECTNESS
     )
 ) {

--- a/detectors/src/main/kotlin/com/serchinastico/lin/detectors/onlyConstantsInTypeDetector.kt
+++ b/detectors/src/main/kotlin/com/serchinastico/lin/detectors/onlyConstantsInTypeDetector.kt
@@ -1,0 +1,26 @@
+package com.serchinastico.lin.detectors
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Scope
+import com.serchinastico.lin.annotations.Detector
+import com.serchinastico.lin.dsl.detector
+import com.serchinastico.lin.dsl.issue
+import org.jetbrains.uast.UClass
+
+@Detector
+fun onlyConstantsInType() = detector(
+    issue(
+        Scope.JAVA_FILE_SCOPE,
+        "Using a class to store only constants is bad practice",
+        """Classes holding only constant values are often a code smell. Constant values should be placed on the class
+            | they are being used instead and, if there is more than one place where the constant is used, move them
+            | to wherever they make more sense.
+        """.trimMargin(),
+        Category.PERFORMANCE
+    )
+) {
+    type { suchThat { it.onlyHasStaticFinalFields } }
+}
+
+private inline val UClass.onlyHasStaticFinalFields: Boolean
+    get() = methods.all { it.isConstructor } && fields.all { it.isStatic && it.isFinal }

--- a/detectors/src/test/kotlin/com/serchinastico/lin/detectors/NoSetOnClickListenerCallsDetectorTest.kt
+++ b/detectors/src/test/kotlin/com/serchinastico/lin/detectors/NoSetOnClickListenerCallsDetectorTest.kt
@@ -83,7 +83,6 @@ class NoSetOnClickListenerCallsDetectorTest : LintTest {
         ) toHave NoErrors
     }
 
-
     @Test
     fun inKotlinClass_whenCallIsSetOnClickListener_detectsError() {
         expect(

--- a/detectors/src/test/kotlin/com/serchinastico/lin/detectors/OnlyConstantsInTypeDetectorTest.kt
+++ b/detectors/src/test/kotlin/com/serchinastico/lin/detectors/OnlyConstantsInTypeDetectorTest.kt
@@ -1,0 +1,117 @@
+package com.serchinastico.lin.detectors
+
+import com.serchinastico.lin.detectors.test.LintTest
+import com.serchinastico.lin.detectors.test.LintTest.Expectation.NoErrors
+import com.serchinastico.lin.detectors.test.LintTest.Expectation.SomeError
+import org.junit.Test
+
+class OnlyConstantsInTypeDetectorTest : LintTest {
+
+    override val issue = OnlyConstantsInTypeDetector.issue
+
+    @Test
+    fun inJavaClass_whenClassHasMethods_detectsNoErrors() {
+        expect(
+            """
+                |package foo;
+                |
+                |class TestClass {
+                |   public static final String str = "";
+                |
+                |   public void main(String[] args) {}
+                |}
+            """.inJava
+        ) toHave NoErrors
+    }
+
+    @Test
+    fun inJavaClass_whenClassHasNonStaticFields_detectsNoErrors() {
+        expect(
+            """
+                |package foo;
+                |
+                |class TestClass {
+                |   public static final String str = "";
+                |   private String nonStaticStr;
+                |}
+            """.inJava
+        ) toHave NoErrors
+    }
+
+    @Test
+    fun inJavaClass_whenClassHasNoFieldsNorMethods_detectsError() {
+        expect(
+            """
+                |package foo;
+                |
+                |class TestClass {
+                |   public static final String str;
+                |}
+            """.inJava
+        ) toHave SomeError("src/foo/TestClass.java")
+    }
+
+    @Test
+    fun inKotlinClass_whenClassHasMethods_detectsNoErrors() {
+        expect(
+            """
+                |package foo
+                |
+                |class TestClass {
+                |
+                |   companion object {
+                |     const val str: String = ""
+                |   }
+                |
+                |   public fun main(args: Array<String>) {}
+                |}
+            """.inKotlin
+        ) toHave NoErrors
+    }
+
+    @Test
+    fun inKotlinClass_whenClassHasNonStaticFields_detectsNoErrors() {
+        expect(
+            """
+                |package foo
+                |
+                |class TestClass {
+                |
+                |   companion object {
+                |     const val str: String = ""
+                |   }
+                |
+                |   val anotherStr: String = ""
+                |}
+            """.inKotlin
+        ) toHave NoErrors
+    }
+
+    @Test
+    fun inKotlinClass_whenClassHasNoFieldsNorMethods_detectsErrors() {
+        expect(
+            """
+                |package foo
+                |
+                |class TestClass {
+                |   companion object {
+                |     const val str: String = ""
+                |   }
+                |}
+            """.inKotlin
+        ) toHave SomeError("src/foo/TestClass.kt")
+    }
+
+    @Test
+    fun inKotlinObject_whenItHasNoFieldsNorMethods_detectsErrors() {
+        expect(
+            """
+                |package foo
+                |
+                |object TestClass {
+                |   const val str: String = ""
+                |}
+            """.inKotlin
+        ) toHave SomeError("src/foo/TestClass.kt")
+    }
+}


### PR DESCRIPTION
:pushpin: **References**

* Issue: #19 

:cyclone: **Git merge message**

* Create a new rule that checks that there are no types (classes/interfaces) with only constant definitions. This is usually a smell and there are probably better places to put those values instead. 