### PR TITLE
Dependant rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Add the `detectors` module dependencies to your project and the `dsl` module as 
 
 ```groovy
 dependencies {
-    lintChecks 'com.serchinastico.lin:detectors:0.0.1'
-    lintClassPath 'com.serchinastico.lin:dsl:0.0.1'
+    lintChecks 'com.serchinastico.lin:detectors:0.0.2'
+    lintClassPath 'com.serchinastico.lin:dsl:0.0.2'
 }
 ```
 
@@ -41,8 +41,8 @@ If you want to write your own detectors just add the `dsl` and `annotations` mod
 
 ```groovy
 dependencies {
-    compileOnly 'com.serchinastico.lin:dsl:0.0.1'
-    compileOnly 'com.serchinastico.lin:annotations:0.0.1'
+    compileOnly 'com.serchinastico.lin:dsl:0.0.2'
+    compileOnly 'com.serchinastico.lin:annotations:0.0.2'
 }
 ```
 
@@ -174,7 +174,7 @@ Because Lin uses backtracking on the process of finding the best match for rules
 }
 ```
 
-The `storage` property is just a `MutableMap<String, String>`. The matching algorithm takes care of keeping the map in a coherent state while doing the search so that you won't find values stored in failing rules.
+The `storage` property is just a `MutableMap<String, String>`. The matching algorithm takes care of keeping the map in a coherent state while doing the search so that you won't find values stored in failing rules. **All siblings and child nodes will see stored values.**
 
 It's also important to keep in mind that Lin will try to match rules in any order. The most important implication is that even if you define a rule in a specific order Lin might find matches in the opposite:
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 
 allprojects {
     apply plugin: "com.github.dcendents.android-maven"
+    apply plugin: "maven-publish"
 
     group = "com.github.serchinastico.lin"
     version = "0.0.2"

--- a/build.gradle
+++ b/build.gradle
@@ -4,22 +4,23 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath "com.android.tools.build:gradle:3.2.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.11"
         classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.13.0"
+        classpath "com.github.dcendents:android-maven-gradle-plugin:2.0"
     }
 }
 
 allprojects {
+    apply plugin: "com.github.dcendents.android-maven"
+
+    group = "com.github.serchinastico.lin"
+    version = "0.0.2"
+
     repositories {
         google()
         jcenter()
     }
-}
-
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
 }
 
 apply plugin: "com.vanniktech.android.junit.jacoco"

--- a/detectors/src/main/kotlin/com/serchinastico/lin/detectors/wrongSyntheticViewReference.kt
+++ b/detectors/src/main/kotlin/com/serchinastico/lin/detectors/wrongSyntheticViewReference.kt
@@ -1,0 +1,64 @@
+package com.serchinastico.lin.detectors
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Scope
+import com.serchinastico.lin.annotations.Detector
+import com.serchinastico.lin.dsl.CustomParameters
+import com.serchinastico.lin.dsl.detector
+import com.serchinastico.lin.dsl.issue
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.UImportStatement
+
+private val KOTLINX_SYNTHETIC_VIEW_IMPORT = """kotlinx\.android\.synthetic\.main\.(.*)""".toRegex()
+private val LAYOUT_EXPRESSION = """R\.layout\.(.*)""".toRegex()
+
+@Detector
+fun wrongSyntheticViewReference() = detector(
+    issue(
+        Scope.JAVA_FILE_SCOPE,
+        "References to synthetic views not directly defined in this class or its ancestors layout",
+        """Imports to kotlinx synthetic views other than the ones defined in the layout referenced in this
+            | or its ancestor classes is mostly a typo. If you want to reference views from custom views abstract them
+            | with methods in order to keep a low coupling with its specific implementation.
+        """.trimMargin(),
+        Category.CORRECTNESS
+    )
+) {
+    import {
+        suchThat { it.isSyntheticViewImport }
+        mappingParameters(::storeImportedLayout)
+    }
+
+    expression {
+        suchThatParams(::isDifferentThanImportedLayout)
+    }
+}
+
+private val UImportStatement.isSyntheticViewImport: Boolean
+    get() {
+        val importedString = importReference?.asRenderString() ?: return false
+        return KOTLINX_SYNTHETIC_VIEW_IMPORT.matches(importedString)
+    }
+
+private fun storeImportedLayout(node: UImportStatement, params: CustomParameters): CustomParameters {
+    val importedString = node.importReference?.asRenderString() ?: return params
+    val importedLayout = KOTLINX_SYNTHETIC_VIEW_IMPORT
+        .matchEntire(importedString)
+        ?.groups
+        ?.get(1)
+        ?.value ?: return params
+
+    return params.plus("Imported Layout" to importedLayout)
+}
+
+private fun isDifferentThanImportedLayout(
+    node: UExpression,
+    params: CustomParameters
+): Boolean {
+    val importedLayout = params["Imported Layout"] ?: return false
+    val usedLayout = LAYOUT_EXPRESSION.matchEntire(node.asRenderString())
+        ?.groups
+        ?.get(1)
+        ?.value ?: return false
+    return usedLayout != importedLayout
+}

--- a/detectors/src/test/kotlin/com/serchinastico/lin/detectors/WrongSyntheticViewReferenceDetectorTest.kt
+++ b/detectors/src/test/kotlin/com/serchinastico/lin/detectors/WrongSyntheticViewReferenceDetectorTest.kt
@@ -21,7 +21,7 @@ class WrongSyntheticViewReferenceDetectorTest : LintTest {
     override val issue = WrongSyntheticViewReferenceDetector.issue
 
     @Test
-    fun inKotlinActivity_whenImportReferencesDifferentLayout_detectsError() {
+    fun inKotlinActivity_whenImportReferencesFromDifferentLayout_detectsError() {
         expect(
             resourcesFile,
             """
@@ -38,7 +38,25 @@ class WrongSyntheticViewReferenceDetectorTest : LintTest {
     }
 
     @Test
-    fun inKotlinActivity_whenImportReferencesSameLayout_detectsNoErrors() {
+    fun inKotlinActivity_whenImportReferencesFromBothSameAndDifferentLayout_detectsError() {
+        expect(
+            resourcesFile,
+            """
+                |package foo
+                |
+                |import foo.R
+                |import kotlinx.android.synthetic.main.activity_test_1.*
+                |import kotlinx.android.synthetic.main.activity_test_2.*
+                |
+                |class TestClass: Activity() {
+                |   override val layoutId = R.layout.activity_test_1
+                |}
+            """.inKotlin
+        ) toHave SomeError("src/foo/TestClass.kt")
+    }
+
+    @Test
+    fun inKotlinActivity_whenImportReferencesFromSameLayout_detectsNoErrors() {
         expect(
             resourcesFile,
             """

--- a/detectors/src/test/kotlin/com/serchinastico/lin/detectors/WrongSyntheticViewReferenceDetectorTest.kt
+++ b/detectors/src/test/kotlin/com/serchinastico/lin/detectors/WrongSyntheticViewReferenceDetectorTest.kt
@@ -1,0 +1,56 @@
+package com.serchinastico.lin.detectors
+
+import com.serchinastico.lin.detectors.test.LintTest
+import com.serchinastico.lin.detectors.test.LintTest.Expectation.NoErrors
+import com.serchinastico.lin.detectors.test.LintTest.Expectation.SomeError
+import org.junit.Test
+
+class WrongSyntheticViewReferenceDetectorTest : LintTest {
+
+    private val resourcesFile = """
+            |package foo;
+            |
+            |public final class R {
+            |   public static final class layout {
+            |       public static final int activity_test_1=0x7f010000;
+            |       public static final int activity_test_2=0x7f020000;
+            |   }
+            |}
+        """.inJava
+
+    override val issue = WrongSyntheticViewReferenceDetector.issue
+
+    @Test
+    fun inKotlinActivity_whenImportReferencesDifferentLayout_detectsError() {
+        expect(
+            resourcesFile,
+            """
+                |package foo
+                |
+                |import foo.R
+                |import kotlinx.android.synthetic.main.activity_test_2.*
+                |
+                |class TestClass: Activity() {
+                |   override val layoutId = R.layout.activity_test_1
+                |}
+            """.inKotlin
+        ) toHave SomeError("src/foo/TestClass.kt")
+    }
+
+    @Test
+    fun inKotlinActivity_whenImportReferencesSameLayout_detectsNoErrors() {
+        expect(
+            resourcesFile,
+            """
+                |package foo
+                |
+                |import foo.R
+                |import kotlinx.android.synthetic.main.activity_test_1.*
+                |
+                |class TestClass: Activity() {
+                |   override val layoutId = R.layout.activity_test_1
+                |}
+            """.inKotlin
+        ) toHave NoErrors
+    }
+}

--- a/dsl/src/main/kotlin/com/serchinastico/lin/dsl/dsl.kt
+++ b/dsl/src/main/kotlin/com/serchinastico/lin/dsl/dsl.kt
@@ -74,14 +74,27 @@ sealed class Quantifier {
 fun file(quantifier: Quantifier = Quantifier.Any, block: LinRule.File.() -> LinRule<UFile>) =
     LinRule.File().block().also { it.quantifier = quantifier }
 
+typealias CustomParameters = Map<String, String>
+
 sealed class LinRule<out T : UElement>(val elementType: KClass<out T>) {
 
     var children = mutableListOf<LinRule<*>>()
-    var reportingPredicate: (UElement) -> Boolean = { true }
+    var reportingPredicate: (UElement, CustomParameters) -> Boolean = { _, _ -> true }
     var quantifier: Quantifier = Quantifier.Any
+    var customParametersMap: (UElement, CustomParameters) -> CustomParameters = { _, params -> params }
 
     fun suchThat(predicate: (T) -> Boolean): LinRule<T> {
-        reportingPredicate = { predicate(it as T) }
+        reportingPredicate = { element, _ -> predicate(element as T) }
+        return this
+    }
+
+    fun suchThatParams(predicate: (T, CustomParameters) -> Boolean): LinRule<T> {
+        reportingPredicate = { element, params -> predicate(element as T, params) }
+        return this
+    }
+
+    fun mappingParameters(map: (T, CustomParameters) -> CustomParameters): LinRule<T> {
+        customParametersMap = { element, params -> map(element as T, params) }
         return this
     }
 

--- a/dsl/src/main/kotlin/com/serchinastico/lin/dsl/dsl.kt
+++ b/dsl/src/main/kotlin/com/serchinastico/lin/dsl/dsl.kt
@@ -74,27 +74,20 @@ sealed class Quantifier {
 fun file(quantifier: Quantifier = Quantifier.Any, block: LinRule.File.() -> LinRule<UFile>) =
     LinRule.File().block().also { it.quantifier = quantifier }
 
-typealias CustomParameters = Map<String, String>
+typealias Storage = MutableMap<String, String>
+
+interface LinContext {
+    val storage: Storage
+}
 
 sealed class LinRule<out T : UElement>(val elementType: KClass<out T>) {
 
     var children = mutableListOf<LinRule<*>>()
-    var reportingPredicate: (UElement, CustomParameters) -> Boolean = { _, _ -> true }
+    var reportingPredicate: LinContext.(UElement) -> Boolean = { true }
     var quantifier: Quantifier = Quantifier.Any
-    var customParametersMap: (UElement, CustomParameters) -> CustomParameters = { _, params -> params }
 
-    fun suchThat(predicate: (T) -> Boolean): LinRule<T> {
-        reportingPredicate = { element, _ -> predicate(element as T) }
-        return this
-    }
-
-    fun suchThatParams(predicate: (T, CustomParameters) -> Boolean): LinRule<T> {
-        reportingPredicate = { element, params -> predicate(element as T, params) }
-        return this
-    }
-
-    fun mappingParameters(map: (T, CustomParameters) -> CustomParameters): LinRule<T> {
-        customParametersMap = { element, params -> map(element as T, params) }
+    fun suchThat(predicate: LinContext.(T) -> Boolean): LinRule<T> {
+        reportingPredicate = { element -> predicate(element as T) }
         return this
     }
 

--- a/dsl/src/main/kotlin/com/serchinastico/lin/dsl/visitor.kt
+++ b/dsl/src/main/kotlin/com/serchinastico/lin/dsl/visitor.kt
@@ -41,3 +41,16 @@ data class LinVisitor(val detector: LinDetector) : UastVisitor {
         currentNode = currentNode?.parent
     }
 }
+
+fun LinRule<UElement>.allUElementSuperClasses(): List<KClass<out UElement>> {
+    val superClasses = mutableSetOf<KClass<out UElement>>()
+    val nodesToProcess = mutableListOf(this)
+
+    while (nodesToProcess.isNotEmpty()) {
+        val currentNode = nodesToProcess.removeAt(0)
+        superClasses.add(currentNode.elementType)
+        nodesToProcess.addAll(currentNode.children)
+    }
+
+    return superClasses.toList()
+}


### PR DESCRIPTION
:pushpin: **References**

* Issue: #32 , #30 

:cyclone: **Git merge message**

* Create the `WrongSyntheticViewReferenceDetector` definition. It makes sure we are not importing the wrong kotlinx synthetic views by looking for differences between the import layout and any other layout defined in the same class.
* Create a new `LinContext` class that for now only holds what we called the `storage`. It is just a mutable map from strings to strings where we can store temporal information to make dependant rules. It is passed as the receiver of the `suchThat` function.
* Adapt the matching algorithm to keep the context in a correct state by copying it every time we want to evaluate a search branch.