### PR TITLE
No findViewById calls

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -2,5 +2,5 @@ apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.3.10"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     lintChecks project(configuration: 'lintChecks', path: ':detectors')
     lintClassPath project(":dsl")
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.10"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11"
     implementation 'com.android.support:appcompat-v7:28.0.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.2.1"
+        classpath "com.android.tools.build:gradle:3.3.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.11"
         classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.13.0"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.0"

--- a/detectors/build.gradle
+++ b/detectors/build.gradle
@@ -19,17 +19,17 @@ dependencies {
     compileOnly project(":annotations")
     kapt project(":processor")
 
-    compileOnly 'com.android.tools.lint:lint:26.2.1'
-    compileOnly 'com.android.tools.lint:lint-api:26.2.1'
-    compileOnly 'com.android.tools.lint:lint-checks:26.2.1'
+    compileOnly 'com.android.tools.lint:lint:26.3.0'
+    compileOnly 'com.android.tools.lint:lint-api:26.3.0'
+    compileOnly 'com.android.tools.lint:lint-checks:26.3.0'
 
     testCompile 'junit:junit:4.12'
     testCompile project(":dsl")
     testCompile 'org.assertj:assertj-core:3.3.0'
     testCompile 'org.mockito:mockito-core:2.23.0'
-    testCompile 'com.android.tools.lint:lint:26.2.1'
-    testCompile 'com.android.tools.lint:lint-tests:26.2.1'
-    testCompile 'com.android.tools:testutils:26.2.1'
+    testCompile 'com.android.tools.lint:lint:26.3.0'
+    testCompile 'com.android.tools.lint:lint-tests:26.3.0'
+    testCompile 'com.android.tools:testutils:26.3.0'
 
     lintChecks files(jar)
 }

--- a/detectors/src/main/kotlin/com/serchinastico/lin/detectors/noFindViewByIdCallsDetector.kt
+++ b/detectors/src/main/kotlin/com/serchinastico/lin/detectors/noFindViewByIdCallsDetector.kt
@@ -1,0 +1,32 @@
+package com.serchinastico.lin.detectors
+
+import com.android.tools.lint.detector.api.Scope
+import com.serchinastico.lin.annotations.Detector
+import com.serchinastico.lin.dsl.detector
+import com.serchinastico.lin.dsl.isClassOrSubclassOf
+import com.serchinastico.lin.dsl.issue
+import org.jetbrains.uast.UCallExpression
+
+@Detector
+fun noFindViewByIdCalls() = detector(
+    issue(
+        Scope.JAVA_FILE_SCOPE,
+        "There should not be calls to findViewById",
+        """Nowadays there are better ways to synthetize these calls into a more concise declaration with tools
+            | like ButterKnife. See https://github.com/JakeWharton/butterknife or
+            | https://kotlinlang.org/docs/tutorials/android-plugin.html#view-binding""".trimMargin()
+    )
+) {
+    callExpression { suchThat { it.isFindViewByIdCall } }
+}
+
+private inline val UCallExpression.isFindViewByIdCall: Boolean
+    get() {
+        val receiverType = receiverType ?: return false
+
+        val isReceiverChildOfActivityOrView =
+            receiverType.isClassOrSubclassOf("android.app.Activity", "android.view.View")
+        val isMethodFindViewById = methodIdentifier?.name == "findViewById"
+
+        return isReceiverChildOfActivityOrView && isMethodFindViewById
+    }

--- a/detectors/src/main/kotlin/com/serchinastico/lin/detectors/noFindViewByIdCallsDetector.kt
+++ b/detectors/src/main/kotlin/com/serchinastico/lin/detectors/noFindViewByIdCallsDetector.kt
@@ -27,6 +27,7 @@ private inline val UCallExpression.isFindViewByIdCall: Boolean
         val isReceiverChildOfActivityOrView =
             receiverType.isClassOrSubclassOf("android.app.Activity", "android.view.View")
         val isMethodFindViewById = methodIdentifier?.name == "findViewById"
+        val isNotAndroidContentId = valueArguments.firstOrNull()?.asSourceString() == "android.R.id.content"
 
-        return isReceiverChildOfActivityOrView && isMethodFindViewById
+        return isReceiverChildOfActivityOrView && isMethodFindViewById && !isNotAndroidContentId
     }

--- a/detectors/src/test/kotlin/com/serchinastico/lin/detectors/NoFindViewByIdCallsDetectorTest.kt
+++ b/detectors/src/test/kotlin/com/serchinastico/lin/detectors/NoFindViewByIdCallsDetectorTest.kt
@@ -18,6 +18,15 @@ class NoFindViewByIdCallsDetectorTest : LintTest {
             |   }
             |}
         """.inJava
+    private val androidResourcesFile = """
+            |package android;
+            |
+            |public final class R {
+            |   public static final class id {
+            |       public static final int content=0x7f010000;
+            |   }
+            |}
+        """.inJava
 
 
     @Test
@@ -60,6 +69,27 @@ class NoFindViewByIdCallsDetectorTest : LintTest {
                 |}
             """.inJava
         ) toHave SomeError("src/foo/TestClass.java")
+    }
+
+    @Test
+    fun inJavaClass_whenCallIsFindViewByIdToAndroidContent_detectsNoError() {
+        expect(
+            androidResourcesFile,
+            resourcesFile,
+            """
+                |package foo;
+                |
+                |import android.view.View;
+                |
+                |class TestClass {
+                |   private View view;
+                |
+                |   public void main(String[] args) {
+                |       view.findViewById(android.R.id.content);
+                |   }
+                |}
+            """.inJava
+        ) toHave NoErrors
     }
 
     @Test
@@ -122,6 +152,27 @@ class NoFindViewByIdCallsDetectorTest : LintTest {
                 |}
             """.inKotlin
         ) toHave SomeError("src/foo/TestClass.kt")
+    }
+
+    @Test
+    fun inKotlinClass_whenCallIsFindViewByIdToAndroidContent_detectsNoError() {
+        expect(
+            androidResourcesFile,
+            resourcesFile,
+            """
+                |package foo
+                |
+                |import android.view.View
+                |
+                |class TestClass {
+                |   private lateinit var view: View
+                |
+                |   public fun main(args: Array<String>) {
+                |       view.findViewById(android.R.id.content)
+                |   }
+                |}
+            """.inKotlin
+        ) toHave NoErrors
     }
 
     @Test

--- a/detectors/src/test/kotlin/com/serchinastico/lin/detectors/NoFindViewByIdCallsDetectorTest.kt
+++ b/detectors/src/test/kotlin/com/serchinastico/lin/detectors/NoFindViewByIdCallsDetectorTest.kt
@@ -1,0 +1,145 @@
+package com.serchinastico.lin.detectors
+
+import com.serchinastico.lin.detectors.test.LintTest
+import com.serchinastico.lin.detectors.test.LintTest.Expectation.NoErrors
+import com.serchinastico.lin.detectors.test.LintTest.Expectation.SomeError
+import org.junit.Test
+
+class NoFindViewByIdCallsDetectorTest : LintTest {
+
+    override val issue = NoFindViewByIdCallsDetector.issue
+
+    private val resourcesFile = """
+            |package foo;
+            |
+            |public final class R {
+            |   public static final class id {
+            |       public static final int my_button=0x7f010000;
+            |   }
+            |}
+        """.inJava
+
+
+    @Test
+    fun inJavaClass_whenCallIsNotFindViewById_detectsNoErrors() {
+        expect(
+            resourcesFile,
+            """
+                |package foo;
+                |
+                |import android.view.View;
+                |import foo.R;
+                |
+                |class TestClass {
+                |   private View view;
+                |
+                |   public void main(String[] args) {
+                |       view.doNotFindViewById(R.id.my_button);
+                |   }
+                |}
+            """.inJava
+        ) toHave NoErrors
+    }
+
+    @Test
+    fun inJavaClass_whenCallIsFindViewById_detectsError() {
+        expect(
+            resourcesFile,
+            """
+                |package foo;
+                |
+                |import android.view.View;
+                |import foo.R;
+                |
+                |class TestClass {
+                |   private View view;
+                |
+                |   public void main(String[] args) {
+                |       view.findViewById(R.id.my_button);
+                |   }
+                |}
+            """.inJava
+        ) toHave SomeError("src/foo/TestClass.java")
+    }
+
+    @Test
+    fun inJavaClass_whenCallIsNotAndroidViewSetOnClickListener_detectsNoErrors() {
+        expect(
+            resourcesFile,
+            """
+                |package foo;
+                |
+                |import foo.R;
+                |
+                |class TestClass {
+                |   public void main(String[] args) {
+                |       findViewById(R.id.my_button);
+                |   }
+                |
+                |   private void findViewById(int id) {}
+                |}
+            """.inJava
+        ) toHave NoErrors
+    }
+
+    @Test
+    fun inKotlinClass_whenCallIsNotFindViewById_detectsNoErrors() {
+        expect(
+            resourcesFile,
+            """
+                |package foo
+                |
+                |import android.view.View
+                |import foo.R
+                |
+                |class TestClass {
+                |   private lateinit var view: View
+                |
+                |   public fun main(args: Array<String>) {
+                |       view.doNotFindViewById(R.id.my_button)
+                |   }
+                |}
+            """.inKotlin
+        ) toHave NoErrors
+    }
+
+    @Test
+    fun inKotlinClass_whenCallIsFindViewById_detectsError() {
+        expect(
+            resourcesFile,
+            """
+                |package foo
+                |
+                |import android.view.View
+                |import foo.R
+                |
+                |class TestClass {
+                |   private lateinit var view: View
+                |
+                |   public fun main(args: Array<String>) {
+                |       view.findViewById(R.id.my_button)
+                |   }
+                |}
+            """.inKotlin
+        ) toHave SomeError("src/foo/TestClass.kt")
+    }
+
+    @Test
+    fun inKotlinClass_whenCallIsNotAndroidViewSetOnClickListener_detectsNoErrors() {
+        expect(
+            """
+                |package foo
+                |
+                |import foo.R
+                |
+                |class TestClass {
+                |   public fun main(args: Array<String>) {
+                |       findViewById(R.id.my_button)
+                |   }
+                |
+                |   private fun findViewById(id: Int) {}
+                |}
+            """.inKotlin
+        ) toHave NoErrors
+    }
+}

--- a/dsl/build.gradle
+++ b/dsl/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'kotlin'
 
 dependencies {
-    compileOnly 'com.android.tools.lint:lint:26.2.1'
-    compileOnly 'com.android.tools.lint:lint-api:26.2.1'
-    compileOnly 'com.android.tools.lint:lint-checks:26.2.1'
+    compileOnly 'com.android.tools.lint:lint:26.3.0'
+    compileOnly 'com.android.tools.lint:lint-api:26.3.0'
+    compileOnly 'com.android.tools.lint:lint-checks:26.3.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:3.3.0'
     testCompile 'org.mockito:mockito-core:2.23.0'
-    testCompile 'com.android.tools.lint:lint:26.2.1'
-    testCompile 'com.android.tools.lint:lint-tests:26.2.1'
-    testCompile 'com.android.tools:testutils:26.2.1'
+    testCompile 'com.android.tools.lint:lint:26.3.0'
+    testCompile 'com.android.tools.lint:lint-tests:26.3.0'
+    testCompile 'com.android.tools:testutils:26.3.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Jan 20 19:32:24 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     compile project(":annotations")
     compile project(":dsl")
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.3.10"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.3.11"
     implementation "com.squareup:kotlinpoet:1.0.0-RC3"
     implementation "com.google.auto.service:auto-service:1.0-rc4"
     kapt "com.google.auto.service:auto-service:1.0-rc4"


### PR DESCRIPTION
:pushpin: **References**

* Issue: #22 
* Other PRs: #26 

:cyclone: **Git merge message**

* Create a new detector to avoid `findViewById` calls.
* Update dependencies' version to their latest.

:memo: **Notes**

No need to go into detail on the detector itself, it's a copy of the NoSetOnClickListenerDetector.
